### PR TITLE
Nov fixes and updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,7 @@ COPY *sh $PDF/
 COPY *py $PDF/
 COPY annotator $PDF/
 COPY config.py.env $PDF/config.py
-
-COPY 1-s2.0-0031018280900164-main.pdf $PDF/test/
-ARG BLACKSTACK_MODE
+COPY input/ $PDF/input/
 
 RUN mkdir out
 WORKDIR $PDF

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,13 +23,12 @@ COPY *py $PDF/
 COPY annotator $PDF/
 COPY config.py.env $PDF/config.py
 
-COPY test/WH897R_29453_000452.pdf $PDF/test/
+COPY 1-s2.0-0031018280900164-main.pdf $PDF/test/
+ARG BLACKSTACK_MODE
 
 RUN mkdir out
 WORKDIR $PDF
 
 EXPOSE 5555
 
-CMD bash -c "sleep 10; $PDF/preprocess.sh training test/WH897R_29453_000452.pdf; python3 $PDF/server.py"
-#CMD ["./preprocess.sh", "training", "test/WH897R_29453_000452.pdf"]
-
+CMD ["./blackstack_wrapper.sh"]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ A machine learning approach to table and figure extraction. Uses SciKit Learn's 
 Whereas other approaches to table and figure reading depend on content to be well-structured, Blackstack ignores the issue of table and figure _data_ extraction (see [Fonduer](https://github.com/HazyResearch/fonduer)) and instead uses a format-agnostic approach to extracting entities as images that can then be used for future analysis or querying.
 
 ## Installation
+### Recommended
+We recommend using Blackstack via docker-compose (https://docs.docker.com/compose/install/)
+
+### Local
 
 Blackstack relies on a few libraries that you probably need to install, including [ghostscript](https://www.ghostscript.com) and [tesseract](https://github.com/tesseract-ocr/tesseract). If you are using MacOS and [Homebrew](https://brew.sh) you can install them as so:
 
@@ -37,6 +41,37 @@ pip install -r requirements.txt
 ````
 
 ## Getting started
+
+### Docker
+
+The recommended way of running Blackstack is via the supplied `docker-compose.yml`. It can
+be run in either `training` mode to train a new model or in `classified` mode
+to apply the trained model (or the default included one) to a set of documents. The mode of running can be provided
+as an environmental variable when invoking docker-compose:
+
+````
+BLACKSTACK_MODE=classified docker-compose up --no-deps --build --force-recreate
+````
+to apply a model.
+
+To train a new one, the first step is to move the default data so that it doesn't
+interfere with your training.
+
+````
+mv setup/02_example_data.sql setup/02_example_data.sql_bk
+BLACKSTACK_MODE=training docker-compose up --no-deps --build --force-recreate
+````
+to train one. 
+
+On startup, Blackstack will preprocess any documents in the `./input/` directory
+and either serve them up for annotation (in training mode) or apply the model
+(in classified mode).
+
+Preprocessed output will be stored to the `./docs/` directory, and, if running in
+classified mode, extractions will be stored per-document in `./docs/classified/`.
+
+### Standalone
+The tools can also be run individually if the prerequisites are installed locally.
 
 #### Preprocessing
 Before a model can be trained, documents to use as training data must be selected. If you are attempting to extract entities from a specific journal or publisher it is recommended that your training data also come from that journal or publisher. If you are trying to create a general classifier you should have a good sample of documents from across disciplines, publishers, etc.

--- a/annotator/server.py
+++ b/annotator/server.py
@@ -224,4 +224,6 @@ else:
 # print clf.classes_
 
 if __name__ == '__main__':
+    if not os.path.exists("./tmp"):
+        os.mkdir("tmp")
     app.run(host='0.0.0.0', port=5555)

--- a/annotator/server.py
+++ b/annotator/server.py
@@ -9,6 +9,7 @@ import psycopg2
 import matplotlib.pyplot as plt
 import matplotlib.patches as patches
 import numpy as np
+from collections import defaultdict
 from sklearn import svm
 
 # Import database credentials
@@ -86,15 +87,14 @@ def random_area():
     if bad:
         return random_area()
 
-    new_area = {
-        'area_id': area[0],
-        'doc_id': area[1],
-        'page_no': area[2],
-        'x1': area[3],
-        'y1': area[4],
-        'x2': area[5],
-        'y2': area[6]
-    }
+    new_area = defaultdict(float)
+    new_area['area_id'] = area[0]
+    new_area['doc_id'] = area[1]
+    new_area['page_no'] = area[2]
+    new_area['x1'] = area[3]
+    new_area['y1'] = area[4]
+    new_area['x2'] = area[5]
+    new_area['y2'] = area[6]
 
     for each in p:
         # should be label, probability

--- a/blackstack_wrapper.sh
+++ b/blackstack_wrapper.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+
+if [ -z "${BLACKSTACK_MODE}" ]
+then
+    echo "Please specify BLACKSTACK_MODE as an envvar"
+    exit 1
+else
+    BLACKSTACK_MODE=${BLACKSTACK_MODE}
+    echo Running blackstack in $BLACKSTACK_MODE mode.
+    if [ "$BLACKSTACK_MODE" = "classified" ] 
+    then
+        echo classified
+        ./preprocess.sh classified test/1-s2.0-0031018280900164-main.pdf ; 
+        python3 extract.py ./docs/classified/1-s2*/
+    elif [ "$BLACKSTACK_MODE" = "training" ] 
+    then
+        echo training
+        ./preprocess.sh training test/1-s2.0-0031018280900164-main.pdf
+        python3 server.py
+    else
+        echo "Unknown blackstack mode specified. Please choose classified or training."
+    fi
+fi

--- a/blackstack_wrapper.sh
+++ b/blackstack_wrapper.sh
@@ -3,22 +3,34 @@
 
 if [ -z "${BLACKSTACK_MODE}" ]
 then
-    echo "Please specify BLACKSTACK_MODE as an envvar"
-    exit 1
+    echo "No BLACKSTACK_MODE specified -- assuming classification mode on prebuilt model."
+    BLACKSTACK_MODE='classified'
 else
     BLACKSTACK_MODE=${BLACKSTACK_MODE}
-    echo Running blackstack in $BLACKSTACK_MODE mode.
-    if [ "$BLACKSTACK_MODE" = "classified" ] 
-    then
-        echo classified
-        ./preprocess.sh classified test/1-s2.0-0031018280900164-main.pdf ; 
-        python3 extract.py ./docs/classified/1-s2*/
-    elif [ "$BLACKSTACK_MODE" = "training" ] 
-    then
-        echo training
-        ./preprocess.sh training test/1-s2.0-0031018280900164-main.pdf
+fi
+
+echo Running blackstack in $BLACKSTACK_MODE mode.
+if [ "$BLACKSTACK_MODE" = "classified" ] 
+then
+    for doc in input/*.pdf;
+    do
+        filename=$(basename "$doc")
+        docname="${filename%.*}"
+        echo ./preprocess.sh classified input/$filename
+        ./preprocess.sh classified input/$filename
+        echo python3 extract.py ./docs/classified/$docname/
+        python3 extract.py ./docs/classified/$docname/
+    done
+elif [ "$BLACKSTACK_MODE" = "training" ] 
+then
+    for doc in input/*.pdf;
+    do
+        filename=$(basename "$doc")
+        docname="${filename%.*}"
+        ./preprocess.sh training input/$filename
         python3 server.py
-    else
-        echo "Unknown blackstack mode specified. Please choose classified or training."
-    fi
+    done
+else
+    echo "Unknown blackstack mode specified. Please choose classified or training."
+    exit 1
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - BLACKSTACK_MODE=${BLACKSTACK_MODE}
     ports:
       - 5555:5555
+    volumes:
+      - ./docs/:/app/pdf/docs/
 
   postgres:
     image: postgres:10.5-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,4 +19,4 @@ services:
       - POSTGRES_DB=blackstack
     volumes:
       - ./setup:/docker-entrypoint-initdb.d/
-
+      - ./postgres-data:/var/lib/postgresql/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     environment:
       - PG_PASSWORD=blackstack
       - PG_USERNAME=postgres
+      - BLACKSTACK_MODE=${BLACKSTACK_MODE}
     ports:
       - 5555:5555
 

--- a/extract.py
+++ b/extract.py
@@ -425,7 +425,6 @@ def process_page(doc_stats, page):
 
 
 # Entry into table extraction
-@profile
 def extract_tables(document_path):
     # Connect to Postgres
     connection = psycopg2.connect(

--- a/extract.py
+++ b/extract.py
@@ -576,7 +576,8 @@ def extract_tables(document_path):
         fig.legend(patchlist, colormap.keys(), loc='lower center', fontsize='x-small', ncol=int(len(colormap)/2), bbox_transform=fig.transFigure)
         plt.axis('off')
         fig.savefig(document_path + "/annotated/page_%s_with_areatypes.png" % page['page_no'], dpi=400, bbox_inches='tight', pad_inches=0)
-        plt.close(fig)
+        fig.clf()
+        plt.close()
 
     for page in pages:
         page_extracts = process_page(doc_stats, page)

--- a/helpers.py
+++ b/helpers.py
@@ -11,10 +11,6 @@ import matplotlib.patches as patches
 from difflib import SequenceMatcher
 from bs4 import BeautifulSoup
 
-import classifier
-
-clf = classifier.create()
-
 def similar(a, b):
     return SequenceMatcher(None, a, b).ratio()
 

--- a/helpers.py
+++ b/helpers.py
@@ -438,7 +438,7 @@ def area_summary(area):
 
     # Number of words
     try:
-        summary['words'] = len(filter(None, summary['soup'].getText().strip().replace('\n', ' ').replace('  ', ' ').split(' ')))
+        summary['words'] = len(list(filter(None, summary['soup'].getText().strip().replace('\n', ' ').replace('  ', ' ').split(' '))))
     except:
         summary['words'] = 0
 

--- a/helpers.py
+++ b/helpers.py
@@ -473,12 +473,21 @@ def area_summary(area):
         for word_idx, word in enumerate(words):
             wordbbox = extractbbox(word.get('title'))
 
+            word_area = (wordbbox['x2'] - wordbbox['x1']) * (wordbbox['y2'] - wordbbox['y1'])
+            if word_area > summary['area'] or \
+                    wordbbox['x2'] > summary['x2'] or \
+                    wordbbox['x1'] < summary['x1'] or \
+                    wordbbox['y1'] < summary['y1'] or \
+                    wordbbox['y2'] > summary['y2']:
+                print("Word outside of the enclosing area! Tesseract's black box strikes again!")
+                continue
+
             # Record the x coordinate of the first word of each line
             if word_idx == 0:
                 summary['first_word_x'] = wordbbox['x1']
 
             summary['word_heights'].append(wordbbox['y2'] - wordbbox['y1'])
-            summary['word_areas'].append((wordbbox['x2'] - wordbbox['x1']) * (wordbbox['y2'] - wordbbox['y1']))
+            summary['word_areas'].append(word_area)
 
             for x in range(wordbbox['x1'] - summary['x1'], wordbbox['x2'] - summary['x1']):
                 summary['x_gaps'][x] = 1
@@ -524,9 +533,8 @@ def summarize_document(area_stats):
         'word_height_avg': np.nanmean([area['word_height_avg'] for area in area_stats if area['words'] > 0 and area['lines'] > 1]),
         'word_height_avg_median': np.nanmedian([area['word_height_avg'] for area in area_stats if area['words'] > 0 and area['lines'] > 1]),
         'word_height_avg_std': np.nanstd([area['word_height_avg'] for area in area_stats if area['words'] > 0 and area['lines'] > 1]),
-
-        'line_height_avg': np.nanmean([a for a in area['line_heights'] for area in area_stats]),
-        'line_height_std': np.nanstd([a for a in area['line_heights'] for area in area_stats]),
+        'line_height_avg': np.nanmean([height for area in area_stats for height in area["line_heights"]]),
+        'line_height_std': np.nanstd([height for area in area_stats for height in area["line_heights"]]),
         'max_area': max([ area['area'] for area in area_stats ]),
         'max_lines': max([ area['lines'] for area in area_stats ]),
         'max_gaps': max([ len(area['gaps']) for area in area_stats ])

--- a/preprocess.sh
+++ b/preprocess.sh
@@ -20,7 +20,9 @@ mkdir -p docs/$1/$docname
 mkdir -p docs/$1/$docname/png
 mkdir -p docs/$1/$docname/tesseract
 if [ "$1" == "classified" ]
-  then mkdir -p docs/$1/$docname/extracts
+then 
+    mkdir -p docs/$1/$docname/extracts
+    mkdir -p docs/$1/$docname/annotated
 fi
 
 gs -dBATCH -dNOPAUSE -sDEVICE=png16m -dGraphicsAlphaBits=4 -dTextAlphaBits=4 -r600 -sOutputFile="./docs/$1/$docname/png/page_%d.png" $2

--- a/summarize.py
+++ b/summarize.py
@@ -3,6 +3,7 @@ import glob
 import heuristics
 import helpers
 from bs4 import BeautifulSoup
+import codecs
 import psycopg2
 from psycopg2.extensions import AsIs
 
@@ -23,12 +24,12 @@ if len(sys.argv) != 2:
 
 doc_id = sys.argv[1]
 
-page_paths = glob.glob('./docs/' + doc_id + '/tesseract/*.html')
+page_paths = glob.glob('./docs/training/' + doc_id + '/tesseract/*.html')
 
 pages = []
 for page_no, page in enumerate(page_paths):
     # Read in each tesseract page with BeautifulSoup so we can look at the document holistically
-    with open(page) as hocr:
+    with codecs.open(page, "r", "utf-8") as hocr:
         text = hocr.read()
         soup = BeautifulSoup(text, 'html.parser')
         merged_areas = helpers.merge_areas(soup.find_all('div', 'ocr_carea'))


### PR DESCRIPTION

 - Tesseract4 has an issue where a word's bbox can take up the whole page (https://github.com/tesseract-ocr/tesseract/issues/1192) -- blackstack now skips those words
 - Added simple wrapper script + envvar toggle to run docker-compose setup in either `classified` or `training` mode
 - There was some potential weirdness where the list of labels was getting read from annotated docs instead of from the `labels` table. It would crash if you start a new model but don't have examples of each layer.
 - A few python3 fixes  -- 5dcda56 is a critical one. filter() in python3 is a generator, so len(filter(...)) was throwing an exception that was getting silently caught. As a result, things downstream thought all areas contained zero words and document- and area-level heuristics broke.
 - Added annotated page dump (outputs the pages with areas labeled by category